### PR TITLE
Fix: Add Fabric Maven repo for plugin resolution in FabricMod

### DIFF
--- a/FabricMod/settings.gradle
+++ b/FabricMod/settings.gradle
@@ -1,0 +1,14 @@
+pluginManagement {
+    repositories {
+        maven {
+            name = 'Fabric'
+            url = 'https://maven.fabricmc.net/'
+        }
+        mavenCentral() // Also include Maven Central for other plugins if needed
+        gradlePluginPortal() // And the Gradle Plugin Portal for standard plugins
+    }
+}
+
+rootProject.name = 'SR3FabricMod'
+// This line sets the root project name, which is good practice for Gradle projects.
+// The important part for the fix is the pluginManagement block.


### PR DESCRIPTION
The FabricMod build was failing because the 'fabric-loom' plugin could not be found. This was due to the Fabric Maven repository not being declared in the plugin management section of the Gradle settings.

This commit updates `FabricMod/settings.gradle` to include a `pluginManagement` block that specifies the Fabric Maven repository (`https://maven.fabricmc.net/`) as a source for Gradle plugins. The Gradle Plugin Portal and Maven Central were also added for completeness.

This change should allow Gradle to correctly resolve and download the `fabric-loom` plugin, enabling the FabricMod component to build.