### PR TITLE
Retry Fix: Simplify settings.gradle for Fabric Loom plugin

### DIFF
--- a/FabricMod/settings.gradle
+++ b/FabricMod/settings.gradle
@@ -1,14 +1,14 @@
+// FabricMod/settings.gradle
+
 pluginManagement {
     repositories {
         maven {
-            name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
-        mavenCentral() // Also include Maven Central for other plugins if needed
-        gradlePluginPortal() // And the Gradle Plugin Portal for standard plugins
+        gradlePluginPortal()
+        mavenCentral()
     }
 }
 
-rootProject.name = 'SR3FabricMod'
-// This line sets the root project name, which is good practice for Gradle projects.
-// The important part for the fix is the pluginManagement block.
+rootProject.name = 'FabricModProject' // Using a simple, distinct name
+// rootProject.buildFileName = 'build.gradle' // This is default, but can be explicit


### PR DESCRIPTION
This commit attempts another fix for the FabricMod build failing to find the 'fabric-loom' plugin.

I have updated the `FabricMod/settings.gradle` file with a simplified configuration for `pluginManagement`. This version ensures the Fabric Maven repository is listed first and uses a very basic project name, to rule out any subtle syntax or ordering issues with the previous attempts.

The goal remains to allow Gradle to correctly resolve and download the `fabric-loom` plugin.