### PR TITLE
Fix: Correct Fabric Loom version to 1.5.8 in FabricMod

### DIFF
--- a/FabricMod/build.gradle
+++ b/FabricMod/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.5.11'
+    id 'fabric-loom' version '1.5.8'
     id 'maven-publish'
 }
 


### PR DESCRIPTION
The FabricMod build was failing because Gradle could not find version 1.5.11 of the 'fabric-loom' plugin (specifically the artifact fabric-loom:fabric-loom.gradle.plugin:1.5.11) in the configured repositories, including Fabric's own Maven.

Investigation of the Fabric Maven repository revealed that version 1.5.11 does not exist for 'fabric-loom.gradle.plugin'. The latest stable version in the 1.5.x series found was 1.5.8.

This commit updates the version in `FabricMod/build.gradle` from '1.5.11' to '1.5.8' to use an available version of the plugin. This should allow Gradle to download the plugin and proceed with the build.