### PR TITLE
Fix: Address Java compilation errors in FabricMod

### DIFF
--- a/FabricMod/src/main/java/com/project/sr3particles/NetworkListener.java
+++ b/FabricMod/src/main/java/com/project/sr3particles/NetworkListener.java
@@ -1,0 +1,69 @@
+package com.project.sr3particles;
+
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.json.JSONObject;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+
+public class NetworkListener extends WebSocketClient {
+
+    public NetworkListener(URI serverUri) {
+        super(serverUri);
+        System.out.println("NetworkListener initialized with URI: " + serverUri);
+    }
+
+    @Override
+    public void onOpen(ServerHandshake handshakedata) {
+        System.out.println("Connected to WebSocket bridge server: " + getURI());
+        JSONObject idMsg = new JSONObject();
+        idMsg.put("client", "sr3_fabric_mod"); // Identify client
+        idMsg.put("type", "connection_init");
+        send(idMsg.toString());
+    }
+
+    @Override
+    public void onMessage(String message) {
+        System.out.println("SR3Mod NetworkListener received message: " + message);
+        try {
+            JSONObject jsonMessage = new JSONObject(message);
+            String messageType = jsonMessage.optString("type");
+
+            // Example: Pass frame data to ParticleRenderer
+            if ("camera_frame".equals(messageType) && SR3ParticleProjection.particleRenderer != null) {
+                SR3ParticleProjection.particleRenderer.processFrame(jsonMessage);
+            } else if ("boss_event".equals(messageType) && SR3ParticleProjection.bossEntityManager != null) {
+                // Example: SR3ParticleProjection.bossEntityManager.handleBossEvent(jsonMessage);
+                System.out.println("Received boss_event, handler in BossEntityManager would be called.");
+            }
+            // Add more specific message handlers based on actual protocol
+        } catch (Exception e) {
+            System.err.println("Error processing message in NetworkListener: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+    
+    @Override
+    public void onMessage(ByteBuffer bytes) {
+        System.out.println("SR3Mod NetworkListener received binary message (not currently processed).");
+    }
+
+    @Override
+    public void onClose(int code, String reason, boolean remote) {
+        System.out.println("SR3Mod NetworkListener disconnected from WebSocket: " + reason + " (Code: " + code + ", Remote: " + remote + ")");
+    }
+
+    @Override
+    public void onError(Exception ex) {
+        System.err.println("SR3Mod NetworkListener WebSocket error: " + ex.getMessage());
+        ex.printStackTrace();
+    }
+
+    // Note: The connect() call is inherited from WebSocketClient.
+    // SR3ParticleProjection.java was already modified to call:
+    //   networkListener = new NetworkListener(new java.net.URI("ws://localhost:8765"));
+    //   networkListener.connect();
+    // This should work as expected with this class structure.
+}

--- a/FabricMod/src/main/java/com/project/sr3particles/ParticleRenderer.java
+++ b/FabricMod/src/main/java/com/project/sr3particles/ParticleRenderer.java
@@ -5,7 +5,6 @@ import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.particle.DustParticleEffect;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.util.math.Vec3f;
 import org.joml.Vector3f;
 import org.json.JSONObject;
 
@@ -57,7 +56,7 @@ public class ParticleRenderer {
 
                 if (r + g + b > 0.1f) {
                     Vec3d particlePos = planeOffset.add(x * scale - (FRAME_WIDTH * scale) / 2, y * scale, 0);
-                    mc.world.addParticle(new DustParticleEffect(new Vec3f(r, g, b), 1.0f),
+                    mc.world.addParticle(new DustParticleEffect(new org.joml.Vector3f(r, g, b), 1.0f),
                             particlePos.x, particlePos.y, particlePos.z,
                             0, 0, 0);
                 }

--- a/FabricMod/src/main/java/com/project/sr3particles/SR3ParticleProjection.java
+++ b/FabricMod/src/main/java/com/project/sr3particles/SR3ParticleProjection.java
@@ -15,12 +15,17 @@ public class SR3ParticleProjection implements ClientModInitializer {
     public void onInitializeClient() {
         INSTANCE = this;
 
-        networkListener = new NetworkListener();
         bossEntityManager = new BossEntityManager();
         particleRenderer = new ParticleRenderer();
 
         // Start WebSocket client to bridge
-        networkListener.connect("ws://localhost:8765");
+        try {
+            networkListener = new NetworkListener(new java.net.URI("ws://localhost:8765"));
+            networkListener.connect(); // This is a blocking call, consider connectBlocking() or a thread
+        } catch (java.net.URISyntaxException e) {
+            System.err.println("Error creating WebSocket URI: " + e.getMessage());
+            e.printStackTrace();
+        }
 
         // Hook into world render to draw particles every frame
         WorldRenderEvents.END.register(context -> particleRenderer.renderParticles(MinecraftClient.getInstance(), context));


### PR DESCRIPTION
This commit resolves two compilation errors in the FabricMod component:

1.  In `ParticleRenderer.java`:
    - Replaced the import and usage of the outdated `net.minecraft.util.math.Vec3f` with the correct `org.joml.Vector3f` for Minecraft 1.19.4.

2.  For the `NetworkListener` class:
    - Populated the previously empty `NetworkListener.java` file with a functional WebSocket client implementation using `org.java_websocket`.
    - Ensured `SR3ParticleProjection.java` correctly instantiates this `NetworkListener` with the server URI.

These changes should allow the FabricMod Java code to compile successfully.