### PR TITLE
Fix: Correct WorldRenderEvents.END callback parameter type

### DIFF
--- a/FabricMod/src/main/java/com/project/sr3particles/SR3ParticleProjection.java
+++ b/FabricMod/src/main/java/com/project/sr3particles/SR3ParticleProjection.java
@@ -28,6 +28,6 @@ public class SR3ParticleProjection implements ClientModInitializer {
         }
 
         // Hook into world render to draw particles every frame
-        WorldRenderEvents.END.register(context -> particleRenderer.renderParticles(MinecraftClient.getInstance(), context));
+        WorldRenderEvents.END.register(context -> particleRenderer.renderParticles(MinecraftClient.getInstance(), context.worldRenderer()));
     }
 }


### PR DESCRIPTION
The FabricMod build was failing due to an incompatible types error in `SR3ParticleProjection.java`. The `WorldRenderEvents.END` event provides a `WorldRenderContext` object, but the `particleRenderer.renderParticles` method expected a `WorldRenderer` object.

This commit fixes the issue by calling `context.worldRenderer()` within the lambda to pass the correct object type to the `renderParticles` method.