### PR TITLE
CI: Add --stacktrace to PaperPlugin build command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
       # Build PaperPlugin (Java)
       - name: Build PaperPlugin
         working-directory: PaperPlugin
-        run: ./gradlew build --debug
+        run: ./gradlew build --debug --stacktrace
 
       # Set up C++ environment
       - name: Install C++ dependencies


### PR DESCRIPTION
The PaperPlugin build is currently failing without a clear error message in the logs. This commit adds the `--stacktrace` option to the Gradle command for the PaperPlugin build step.

The intention is to get more detailed output from Gradle in case the failure is due to an exception, which might not be fully reported with just the --debug flag.