### PR TITLE
Update PaperPlugin dependency to paper-mojangapi:1.19

### DIFF
--- a/PaperPlugin/build.gradle
+++ b/PaperPlugin/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     implementation 'org.java-websocket:Java-WebSocket:1.5.3'
-    compileOnly 'io.papermc.paper:paper-api:1.19.4-R0.1-SNAPSHOT'
+    compileOnly 'io.papermc.paper:paper-mojangapi:1.19'
 }
 
 java {


### PR DESCRIPTION
As per your direction, this commit changes the Paper API dependency in `PaperPlugin/build.gradle`.

The dependency `io.papermc.paper:paper-api:1.19.4-R0.1-SNAPSHOT` was replaced with `io.papermc.paper:paper-mojangapi:1.19`.

This is intended to resolve a 403 Forbidden error when downloading the previous SNAPSHOT dependency. You have indicated that this new dependency will be compatible with the existing PaperPlugin code.