### PR TITLE
Fix small bugs in bridge server and plugin

### DIFF
--- a/BridgeServer/Bridge.py
+++ b/BridgeServer/Bridge.py
@@ -15,8 +15,10 @@ sr3_status = {
 }
 
 async def handle_client(websocket, path):
-    """ Handles incoming WebSocket connections from Minecraft and SR3. """
+    """Handles incoming WebSocket connections from Minecraft and SR3."""
     global sr3_status
+
+    client_type = "unknown"
 
     try:
         async for message in websocket:

--- a/PaperPlugin/src/main/java/com/project/worldbridge/ChunkCollector.java
+++ b/PaperPlugin/src/main/java/com/project/worldbridge/ChunkCollector.java
@@ -62,8 +62,8 @@ public class ChunkCollector extends BukkitRunnable {
             }
 
             JSONObject playerBox = new JSONObject();
-            Location min = player.getBoundingBox().getMin();
-            Location max = player.getBoundingBox().getMax();
+            var min = player.getBoundingBox().getMin();
+            var max = player.getBoundingBox().getMax();
             playerBox.put("min", new JSONArray(new double[]{min.getX(), min.getY(), min.getZ()}));
             playerBox.put("max", new JSONArray(new double[]{max.getX(), max.getY(), max.getZ()}));
 


### PR DESCRIPTION
## Summary
- avoid unbound variable when websocket disconnects before sending a message
- fix player bounding box type in Paper plugin's chunk collector

## Testing
- `python -m py_compile BridgeServer/Bridge.py`
- `javac PaperPlugin/src/main/java/com/project/worldbridge/ChunkCollector.java` *(fails: package org.bukkit does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_685f38c2e30c832aa4c9e80a8b7e3e28